### PR TITLE
Fix manifest syntax errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "gulp-sourcemaps": "^1.2.*",
     "gulp-notify": "^2.0.*",
     "vinyl-source-stream": "^1.1.*",
-    "gulp-uglify": "^1.1.*"
-    "del": "^1.1.*",
+    "gulp-uglify": "^1.1.*",
+    "del": "^1.1.*"
   },
   "scripts": {
     "start": "nodemon server.js"


### PR DESCRIPTION
Currently, `npm install` results in an error because the `package.json` contains a syntax error. This pull request fixes it, yo.
