### PR TITLE
Add nodemon dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "body-parser": "^1.12.*",
     "lodash": "^3.5.*",
     "request": "^2.54.*",
+    "nodemon": "^1.3.7",
     "querystring": "^0.2.*",
     "oauth": "^0.9.*"
   },


### PR DESCRIPTION
If you add `nodemon` as a dependency, the binary will be added to `node_modules/.bin` so that it won't be required that an end-user developer needs to have it globally installed. Scripts in `package.json` (`npm start`) automatically include `node_modules/.bin` in the PATH.
